### PR TITLE
feat: add masonry grid infinite scroll

### DIFF
--- a/src/components/MasonryGrid.styled.ts
+++ b/src/components/MasonryGrid.styled.ts
@@ -1,9 +1,9 @@
 import styled, { css, DefaultTheme } from 'styled-components';
 import { DEFAULT_COLUMNS } from './MasonryGrid.tsx';
 import { getInheritedColumns } from '../utils/masonry.ts';
-import type { ColumnsConfig } from '../types/masonry.ts';
+import type { GridColumnsConfig } from '../types/masonry.ts';
 
-const getColumnCountCss = (theme: DefaultTheme, columns: number | ColumnsConfig) => {
+const getColumnCountCss = (theme: DefaultTheme, columns: number | GridColumnsConfig) => {
   const cascadedColumns =
     typeof columns === 'number'
       ? { mobile: columns }
@@ -28,7 +28,7 @@ const getColumnCountCss = (theme: DefaultTheme, columns: number | ColumnsConfig)
   `;
 };
 
-export const GridContainer = styled.div<{ $columns: number | ColumnsConfig; $gap: number }>`
+export const GridContainer = styled.div<{ $columns: number | GridColumnsConfig; $gap: number }>`
   column-gap: ${(props) => props.$gap}px;
   ${(props) => getColumnCountCss(props.theme, props.$columns)};
 `;

--- a/src/components/MasonryGrid.tsx
+++ b/src/components/MasonryGrid.tsx
@@ -1,10 +1,21 @@
 import { type ReactNode, Children } from 'react';
 import { GridContainer, GridItem } from './MasonryGrid.styled.ts';
-import type { ColumnsConfig } from '../types/masonry.ts';
+import type { GridColumnsConfig } from '../types/masonry.ts';
 
 interface MasonryGridProps {
+  /**
+   * ReactNode to render for each item.
+   */
   children: ReactNode;
-  columns?: number | ColumnsConfig;
+
+  /**
+   * Number of columns in the grid or a GridColumnsConfig object.
+   */
+  columns?: number | GridColumnsConfig;
+
+  /**
+   * Gap between grid items in pixels.
+   */
   gap?: number;
 }
 

--- a/src/components/gallery/GalleryImage.tsx
+++ b/src/components/gallery/GalleryImage.tsx
@@ -1,7 +1,7 @@
 import Image from '../Image.tsx';
 import { ImageWrapper } from './GalleryImage.styled.ts';
 import type { Viewport } from '../../types/theme.ts';
-import type { ColumnsConfig } from '../../types/masonry.ts';
+import type { GridColumnsConfig } from '../../types/masonry.ts';
 
 interface GalleryImageProps {
   src: string;
@@ -11,7 +11,7 @@ interface GalleryImageProps {
   alt: string;
   srcSet: string;
   mediaQueries: Viewport['mediaQueries'];
-  columns: ColumnsConfig;
+  columns: GridColumnsConfig;
 }
 
 const GalleryImage = ({

--- a/src/hooks/masontry/useGridLayout.ts
+++ b/src/hooks/masontry/useGridLayout.ts
@@ -1,0 +1,74 @@
+import { type RefObject, useEffect, useState, useCallback } from 'react';
+import debounce from 'lodash.debounce';
+import { getColumns } from '../../utils/masonry.ts';
+import type { GridItemPosition, GridColumnsConfig, GridItem } from '../../types/masonry.ts';
+import { Viewport } from '../../types/theme.ts';
+
+type GridLayoutHook = {
+  items: GridItem[];
+  columns: number | GridColumnsConfig;
+  gap: number;
+  containerRef: RefObject<HTMLDivElement>;
+  breakpoints: Viewport['breakpoints'];
+};
+
+/**
+ * Custom hook to calculate the layout positions of grid items.
+ */
+export const useGridLayout = ({
+  items,
+  columns,
+  gap,
+  containerRef,
+  breakpoints,
+}: GridLayoutHook) => {
+  const [positions, setPositions] = useState<GridItemPosition[]>([]);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const updateLayout = useCallback(() => {
+    if (!containerRef.current) return;
+
+    const columnsCount = typeof columns === 'number' ? columns : getColumns(columns, breakpoints);
+
+    const containerWidth = containerRef.current.offsetWidth;
+    const columnWidth = (containerWidth - gap * (columnsCount - 1)) / columnsCount;
+    const columnHeights = Array(columnsCount).fill(0);
+
+    const calculatedPositions = items.map((item) => {
+      const shortestColumn = columnHeights.indexOf(Math.min(...columnHeights));
+      const translateX = shortestColumn * (columnWidth + gap);
+      const translateY = columnHeights[shortestColumn];
+
+      const aspectRatio = item.height / item.width;
+      const itemHeight = columnWidth * aspectRatio;
+      const itemWidth = columnWidth;
+
+      columnHeights[shortestColumn] += itemHeight + gap;
+
+      return {
+        translateX,
+        translateY,
+        width: itemWidth,
+        height: itemHeight,
+      };
+    });
+
+    setPositions(calculatedPositions);
+    setContainerHeight(Math.max(...columnHeights));
+  }, [items, gap, columns, breakpoints, containerRef]);
+
+  // update the layout when items or dimensions change
+  useEffect(() => {
+    updateLayout();
+
+    const debouncedResizeHandler = debounce(updateLayout, 200);
+
+    window.addEventListener('resize', debouncedResizeHandler);
+    return () => {
+      debouncedResizeHandler.cancel();
+      window.removeEventListener('resize', debouncedResizeHandler);
+    };
+  }, [updateLayout]);
+
+  return { positions, containerHeight };
+};

--- a/src/hooks/masontry/useVisibleItems.ts
+++ b/src/hooks/masontry/useVisibleItems.ts
@@ -1,0 +1,93 @@
+import { type RefObject, useEffect, useState, useCallback } from 'react';
+import debounce from 'lodash.debounce';
+import type { GridItemPosition } from '../../types/masonry.ts';
+
+type VisibleItemsHook = {
+  positions: GridItemPosition[];
+  containerRef: RefObject<HTMLDivElement>;
+  overscan: number;
+  gap: number;
+  itemsLength: number;
+};
+
+/**
+ * Custom hook to determine which items are visible in the viewport.
+ */
+export const useVisibleItems = ({
+  positions,
+  containerRef,
+  overscan,
+  gap,
+  itemsLength,
+}: VisibleItemsHook) => {
+  const [visibleItems, setVisibleItems] = useState<number[]>([]);
+
+  const updateVisibleItems = useCallback(() => {
+    if (!positions.length || !containerRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const containerTop = containerRect.top + window.scrollY;
+
+    const scrollTop = window.scrollY;
+    const windowHeight = window.innerHeight;
+
+    const start = scrollTop;
+    const end = scrollTop + windowHeight;
+
+    // create an array with positions and indices
+    const positionsWithIndex = positions.map((pos, index) => ({
+      index,
+      translateY: pos.translateY,
+      height: pos.height,
+    }));
+
+    // sort the array by translateY
+    positionsWithIndex.sort((a, b) => a.translateY - b.translateY);
+
+    const viewportIndices: number[] = [];
+    for (const item of positionsWithIndex) {
+      const itemTop = containerTop + item.translateY;
+      const itemBottom = itemTop + item.height;
+
+      if (itemBottom + gap >= start && itemTop - gap <= end) {
+        viewportIndices.push(item.index);
+      } else if (itemTop - gap > end) {
+        // break if items are sorted
+        break;
+      }
+    }
+
+    if (viewportIndices.length === 0) {
+      setVisibleItems([]);
+      return;
+    }
+
+    const startIndex = Math.max(0, viewportIndices[0] - overscan);
+    const endIndex = Math.min(
+      itemsLength - 1,
+      viewportIndices[viewportIndices.length - 1] + overscan,
+    );
+
+    setVisibleItems(Array.from({ length: endIndex - startIndex + 1 }, (_, i) => startIndex + i));
+  }, [positions, overscan, itemsLength, gap, containerRef]);
+
+  // update visible items on scroll
+  useEffect(() => {
+    updateVisibleItems();
+
+    const throttledScrollHandler = debounce(updateVisibleItems, 50);
+
+    window.addEventListener('scroll', throttledScrollHandler);
+    return () => {
+      throttledScrollHandler.cancel();
+      window.removeEventListener('scroll', throttledScrollHandler);
+    };
+  }, [updateVisibleItems]);
+
+  // update visible items when positions change
+  useEffect(() => {
+    updateVisibleItems();
+  }, [positions, updateVisibleItems]);
+
+  return visibleItems;
+};

--- a/src/hooks/query/usePhoto.ts
+++ b/src/hooks/query/usePhoto.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { getPhoto } from '../api/pexels';
-import type { GetPhotoParams, GetPhotoResponse } from '../types/pexels';
+import { getPhoto } from '../../api/pexels.ts';
+import type { GetPhotoParams, GetPhotoResponse } from '../../types/pexels.ts';
 
 export const usePhoto = (params: GetPhotoParams, options?: { enabled?: boolean }) => {
   return useQuery<GetPhotoResponse, Error>({

--- a/src/hooks/query/usePhotos.ts
+++ b/src/hooks/query/usePhotos.ts
@@ -1,10 +1,10 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { searchPhotos, getCuratedPhotos } from '../api/pexels.ts';
+import { searchPhotos, getCuratedPhotos } from '../../api/pexels.ts';
 import type {
   GetCuratedPhotosParams,
   PhotosResponse,
   SearchPhotosParams,
-} from '../types/pexels.ts';
+} from '../../types/pexels.ts';
 
 type UsePhotosParams = Partial<SearchPhotosParams & GetCuratedPhotosParams>;
 

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -2,13 +2,13 @@ import { useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import VirtualizedMasonryGrid from '../components/VirtualizedMasonryGrid.tsx';
-import { usePhotos } from '../hooks/usePhotos.ts';
-import { getPhotoSrcSet } from '../utils/pexels.ts';
-import type { ColumnsConfig } from '../types/masonry.ts';
 import GalleryImage from '../components/gallery/GalleryImage.tsx';
 import { Main, Section } from '../components/Layout.tsx';
+import { usePhotos } from '../hooks/query/usePhotos.ts';
+import { getPhotoSrcSet } from '../utils/pexels.ts';
+import type { GridColumnsConfig } from '../types/masonry.ts';
 
-const masonryGridColumns: ColumnsConfig = {
+const masonryGridColumns: GridColumnsConfig = {
   mobile: 2,
   tablet: 3,
   laptop: 4,

--- a/src/pages/PhotoPage.tsx
+++ b/src/pages/PhotoPage.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from 'styled-components';
 import { useLocation, useParams, type Location } from 'react-router';
-import { usePhoto } from '../hooks/usePhoto.ts';
+import { usePhoto } from '../hooks/query/usePhoto.ts';
 import PhotoImage from '../components/photo/PhotoImage.tsx';
 import type { Photo } from '../types/pexels.ts';
 import { Main, Section } from '../components/Layout.tsx';

--- a/src/types/masonry.ts
+++ b/src/types/masonry.ts
@@ -1,3 +1,16 @@
 import { Viewport } from './theme.ts';
 
-export type ColumnsConfig = Partial<Viewport['breakpoints']>;
+export type GridColumnsConfig = Partial<Viewport['breakpoints']>;
+
+export type GridItem = {
+  id: string | number;
+  height: number;
+  width: number;
+};
+
+export type GridItemPosition = {
+  translateX: number;
+  translateY: number;
+  width: number;
+  height: number;
+};

--- a/src/utils/masonry.ts
+++ b/src/utils/masonry.ts
@@ -1,9 +1,12 @@
-import type { ColumnsConfig } from '../types/masonry';
+import type { GridColumnsConfig } from '../types/masonry';
 import type { Viewport } from '../types/theme.ts';
 import { DEFAULT_COLUMNS } from '../components/VirtualizedMasonryGrid';
 
-export const getInheritedColumns = (columns: ColumnsConfig, fallback: number): ColumnsConfig => {
-  const inheritedColumns = {} as ColumnsConfig;
+export const getInheritedColumns = (
+  columns: GridColumnsConfig,
+  fallback: number,
+): GridColumnsConfig => {
+  const inheritedColumns = {} as GridColumnsConfig;
   const breakpointsOrder = ['mobile', 'tablet', 'laptop', 'desktop', 'largeScreen'] as const;
 
   breakpointsOrder.forEach((breakpoint, index) => {
@@ -24,7 +27,7 @@ export const getInheritedColumns = (columns: ColumnsConfig, fallback: number): C
 };
 
 export const getColumns = (
-  columns: ColumnsConfig,
+  columns: GridColumnsConfig,
   breakpoints: Viewport['breakpoints'],
 ): number => {
   const inheritedColumns = getInheritedColumns(columns, DEFAULT_COLUMNS);


### PR DESCRIPTION
- added optional loadMore and hasMore to the component API
- added intersection observer for load more trigger-element
- refined calculations to better manage visible items
- added load more functionality to GalleryPage
- moved complex logic from VirtualizedMasonryGrid component to useGridLayout and useVisibleItems custom hooks
- added descriptions of interface APIs of VirtualizedMasonryGrid and MasonryGrid components
- moved GridItem and GridItemPosition type declarations to shared types folder