### PR TITLE
chore: improve image placeholder

### DIFF
--- a/src/components/Image.styled.ts
+++ b/src/components/Image.styled.ts
@@ -4,8 +4,7 @@ interface ImageContainerProps {
   $width?: number;
   $height?: number;
   $fill?: boolean;
-  $placeholderSrc?: string;
-  $loaded: boolean;
+  $placeholderColor?: string;
   $objectFit: string;
 }
 
@@ -17,15 +16,20 @@ const FillCss = css`
   height: 100%;
 `;
 
-const DimensionCss = css<Pick<ImageContainerProps, '$width' | '$height'>>`
+const FixedSizeCss = css<Pick<ImageContainerProps, '$width' | '$height'>>`
   width: ${({ $width }) => $width}px;
   height: ${({ $height }) => $height}px;
 `;
 
 export const ImageContainer = styled.div<ImageContainerProps>`
   position: relative;
+  ${(props) =>
+    props.$placeholderColor &&
+    css`
+      background-color: ${props.$placeholderColor || props.theme.palette.surface.secondary};
+    `}
 
-  ${(props) => (props.$fill ? FillCss : props.$width && props.$height ? DimensionCss : '')}
+  ${(props) => (props.$fill ? FillCss : props.$width && props.$height ? FixedSizeCss : '')}
 `;
 
 interface ImgProps {

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -5,28 +5,42 @@ interface CommonImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   src: string;
   alt: string;
   placeholderSrc?: string;
+  placeholderColor?: string;
   onLoad?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
   onError?: (event: SyntheticEvent<HTMLImageElement, Event>) => void;
   objectFit?: 'contain' | 'cover';
 }
 
-interface FixedSizeImageProps extends CommonImageProps {
+interface PlaceholderSrc {
+  placeholderSrc: string;
+  placeholderColor?: never;
+}
+
+interface PlaceholderColor {
+  placeholderColor: string;
+  placeholderSrc?: never;
+}
+
+interface FixedSizeProps {
   width: number;
   height: number;
   fill?: never;
 }
 
-interface FillImageProps extends CommonImageProps {
+interface FillProps {
   fill: boolean;
   width?: never;
   height?: never;
 }
 
-export type ImageProps = FixedSizeImageProps | FillImageProps;
+type ImageProps = CommonImageProps &
+  (FixedSizeProps | FillProps) &
+  (PlaceholderSrc | PlaceholderColor);
 
 const Image = forwardRef<HTMLDivElement, ImageProps>((props, ref) => {
   const {
     placeholderSrc,
+    placeholderColor,
     width,
     height,
     fill,
@@ -53,8 +67,7 @@ const Image = forwardRef<HTMLDivElement, ImageProps>((props, ref) => {
       $width={width}
       $height={height}
       $fill={fill}
-      $placeholderSrc={placeholderSrc}
-      $loaded={loaded}
+      $placeholderColor={placeholderColor}
       $objectFit={objectFit}
     >
       {placeholderSrc ? (

--- a/src/components/gallery/GalleryImage.tsx
+++ b/src/components/gallery/GalleryImage.tsx
@@ -5,21 +5,21 @@ import type { GridColumnsConfig } from '../../types/masonry.ts';
 
 interface GalleryImageProps {
   src: string;
-  placeholderSrc: string;
   height: number;
   width: number;
   alt: string;
   srcSet: string;
+  color: string;
   mediaQueries: Viewport['mediaQueries'];
   columns: GridColumnsConfig;
 }
 
 const GalleryImage = ({
   src,
-  placeholderSrc,
   height,
   width,
   alt,
+  color,
   srcSet,
   mediaQueries,
   columns,
@@ -33,14 +33,7 @@ const GalleryImage = ({
 
   return (
     <ImageWrapper $aspectRatio={height / width || 1}>
-      <Image
-        fill
-        src={src}
-        placeholderSrc={placeholderSrc}
-        alt={alt}
-        srcSet={srcSet}
-        sizes={sizes}
-      />
+      <Image fill src={src} placeholderColor={color} alt={alt} srcSet={srcSet} sizes={sizes} />
     </ImageWrapper>
   );
 };

--- a/src/components/photo/PhotoImage.tsx
+++ b/src/components/photo/PhotoImage.tsx
@@ -7,30 +7,21 @@ interface PhotoImageProps {
   src: string;
   alt: string;
   srcSet: string;
-  placeholderSrc: string;
-  bgColor: string;
+  color: string;
 }
 
-const PhotoImage = ({
-  height,
-  width,
-  src,
-  alt,
-  srcSet,
-  placeholderSrc,
-  bgColor,
-}: PhotoImageProps) => {
+const PhotoImage = ({ height, width, src, alt, srcSet, color }: PhotoImageProps) => {
   const aspectRatio = height / width || 1;
 
   return (
-    <ImageBackground $bgColor={bgColor}>
+    <ImageBackground $bgColor={color}>
       <ImageContainer $aspectRatio={aspectRatio}>
         <ImageWrapper $aspectRatio={aspectRatio}>
           <Image
             src={src}
             alt={alt}
             srcSet={srcSet}
-            placeholderSrc={placeholderSrc}
+            placeholderColor={color}
             fill
             loading="eager"
             fetchPriority="high"

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -95,7 +95,7 @@ const GalleryPage = () => {
             <Link to={`/photo/${photo.id}`} state={photo}>
               <GalleryImage
                 src={photo.src.portrait}
-                placeholderSrc={photo.src.small}
+                color={photo.avg_color}
                 alt={photo.alt}
                 height={photo.height}
                 width={photo.width}

--- a/src/pages/PhotoPage.tsx
+++ b/src/pages/PhotoPage.tsx
@@ -72,12 +72,11 @@ const PhotoPage = () => {
       <Section>
         <PhotoImage
           src={photo.src.portrait}
-          placeholderSrc={photo.src.small}
           alt={photo.alt}
           srcSet={`${photo.src.large} 1x, ${photo.src.large2x} 2x`}
           width={photo.width}
           height={photo.height}
-          bgColor={photo.avg_color}
+          color={photo.avg_color}
         />
       </Section>
       <Section>


### PR DESCRIPTION
- moved image placeholder src from background-image to a separate img element
- added `placeholderColor` prop to Image component API as an alternative of `placeholderSrc`
- replaced `placeholderSrc` with `placeholderColor` where the Image component was used