### PR TITLE
chore: throttle grid scroll is optional

### DIFF
--- a/src/components/VirtualizedMasonryGrid.tsx
+++ b/src/components/VirtualizedMasonryGrid.tsx
@@ -45,6 +45,12 @@ interface VirtualizedMasonryGridProps<T extends GridItem> {
    * Index of the item to scroll to.
    */
   indexToScroll?: number;
+
+  /**
+   * Throttle the scroll event.
+   * Note: This is useful when the scroll event is causing performance issues.
+   */
+  throttledScroll?: boolean;
 }
 
 export const DEFAULT_COLUMNS = 3;
@@ -66,6 +72,7 @@ const VirtualizedMasonryGrid = <T extends GridItem>({
   loadMore,
   hasMore,
   indexToScroll,
+  throttledScroll = true,
 }: VirtualizedMasonryGridProps<T>) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const loaderRef = useRef<HTMLDivElement | null>(null);
@@ -85,6 +92,7 @@ const VirtualizedMasonryGrid = <T extends GridItem>({
     containerRef,
     overscan,
     gap,
+    throttledScroll,
     itemsLength: items.length,
   });
 

--- a/src/hooks/masontry/useVisibleItems.ts
+++ b/src/hooks/masontry/useVisibleItems.ts
@@ -8,6 +8,7 @@ type VisibleItemsHook = {
   overscan: number;
   gap: number;
   itemsLength: number;
+  throttledScroll?: boolean;
 };
 
 /**
@@ -19,6 +20,7 @@ export const useVisibleItems = ({
   overscan,
   gap,
   itemsLength,
+  throttledScroll,
 }: VisibleItemsHook) => {
   const [visibleItems, setVisibleItems] = useState<number[]>([]);
 
@@ -75,14 +77,18 @@ export const useVisibleItems = ({
   useEffect(() => {
     updateVisibleItems();
 
-    const throttledScrollHandler = debounce(updateVisibleItems, 50);
+    const throttledScrollHandler = throttledScroll
+      ? debounce(updateVisibleItems, 50)
+      : updateVisibleItems;
 
     window.addEventListener('scroll', throttledScrollHandler);
     return () => {
-      throttledScrollHandler.cancel();
+      if (throttledScroll) {
+        (throttledScrollHandler as ReturnType<typeof debounce>).cancel();
+      }
       window.removeEventListener('scroll', throttledScrollHandler);
     };
-  }, [updateVisibleItems]);
+  }, [updateVisibleItems, throttledScroll]);
 
   // update visible items when positions change
   useEffect(() => {


### PR DESCRIPTION
- added optional `throttledScroll` prop to `VirtualizedMasonryGrid` component